### PR TITLE
Added capability to use different chip select pin, sleep and wake up

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -36,12 +36,14 @@ class SerialFlashFile;
 class SerialFlashChip
 {
 public:
-	static bool begin();
+	static bool begin(uint8_t pin = 6);
 	static uint32_t capacity(const uint8_t *id);
 	static uint32_t blockSize();
 	static void readID(uint8_t *buf);
 	static void read(uint32_t addr, void *buf, uint32_t len);
 	static bool ready();
+	static void sleep();
+	static void wakeup();
 	static void wait();
 	static void write(uint32_t addr, const void *buf, uint32_t len);
 	static void eraseAll();
@@ -64,6 +66,10 @@ private:
 				// 1 = suspendable program operation
 				// 2 = suspendable erase operation
 				// 3 = busy for realz!!
+	static uint8_t cspin;	// chip select pin
+	static void CSCONFIG();
+    static void CSASSERT();
+	static void CSRELEASE(); 
 };
 
 extern SerialFlashChip SerialFlash;

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -27,18 +27,12 @@
 
 #include "SerialFlash.h"
 
-#define CSCONFIG()  pinMode(6, OUTPUT)
-#define CSASSERT()  digitalWriteFast(6, LOW)
-#define CSRELEASE() digitalWriteFast(6, HIGH)
 #define SPICONFIG   SPISettings(50000000, MSBFIRST, SPI_MODE0)
-
-#if !defined(__arm__) || !defined(CORE_TEENSY)
-#define digitalWriteFast(pin, state) digitalWrite((pin), (state))
-#endif
 
 uint16_t SerialFlashChip::dirindex = 0;
 uint8_t SerialFlashChip::flags = 0;
 uint8_t SerialFlashChip::busy = 0;
+uint8_t SerialFlashChip::cspin = 6;
 
 #define FLAG_32BIT_ADDR		0x01	// larger than 16 MByte address
 #define FLAG_STATUS_CMD70	0x02	// requires special busy flag check
@@ -46,6 +40,28 @@ uint8_t SerialFlashChip::busy = 0;
 #define FLAG_MULTI_DIE		0x08	// multiple die, don't read cross 32M barrier
 #define FLAG_256K_BLOCKS	0x10	// has 256K erase blocks
 #define FLAG_DIE_MASK		0xC0	// top 2 bits count during multi-die erase
+
+void SerialFlashChip::CSCONFIG()  
+{
+	pinMode(cspin, OUTPUT);
+}
+
+void SerialFlashChip::CSASSERT()  
+{
+	#if !defined(__arm__) || !defined(CORE_TEENSY)
+		digitalWrite(cspin, LOW);
+	#else
+		digitalWriteFast(cspin, LOW);
+	#endif
+}
+void SerialFlashChip::CSRELEASE() 
+{
+	#if !defined(__arm__) || !defined(CORE_TEENSY)
+		digitalWrite(cspin, HIGH);
+	#else
+		digitalWriteFast(cspin, HIGH);
+	#endif
+}
 
 void SerialFlashChip::wait(void)
 {
@@ -331,12 +347,14 @@ bool SerialFlashChip::ready()
 //#define FLAG_DIFF_SUSPEND	0x04	// uses 2 different suspend commands
 //#define FLAG_256K_BLOCKS	0x10	// has 256K erase blocks
 
-bool SerialFlashChip::begin()
+bool SerialFlashChip::begin(uint8_t pin)
 {
 	uint8_t id[3];
 	uint8_t f;
 	uint32_t size;
-
+    
+    cspin = pin;
+    
 	SPI.begin();
 	CSCONFIG();
 	CSRELEASE();
@@ -380,6 +398,23 @@ bool SerialFlashChip::begin()
 	flags = f;
 	readID(id);
 	return true;
+}
+
+void SerialFlashChip::sleep()
+{
+	if (busy) wait();
+	SPI.beginTransaction(SPICONFIG);
+	CSASSERT();
+	SPI.transfer(0xB9); // Deep power down command
+	CSRELEASE();
+}
+
+void SerialFlashChip::wakeup()
+{
+	SPI.beginTransaction(SPICONFIG);
+	CSASSERT();
+	SPI.transfer(0xAB); // Wake up from deep power down command
+	CSRELEASE();	
 }
 
 void SerialFlashChip::readID(uint8_t *buf)


### PR DESCRIPTION
I have added the capability to use different chip select pins other than the default 6. Pin usage is selected in the begin() function call. Ideally, this should be declared in the SerialFlash object instantiation but the SerialFlash class lacks this. A better approach would be having SerialFlash as a lower level driver class as a separate library and have the SerialFlashFile class working on top of it.

Sleep capability is added to put the serial flash chip into power down mode as most of these chips is able to consumes as little as 1 uA during this mode.

In order to exit the power down mode, a wake up function call is also added.
