### PR TITLE
Bugfix Capacity (Spansion Chip)

### DIFF
--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -420,6 +420,9 @@ uint32_t SerialFlashChip::capacity(const uint8_t *id)
 {
 	uint32_t n = 1048576; // unknown chips, default to 1 MByte
 
+	if (id[0] == ID0_SPANSION) {
+		n = 1ul << (id[2] + 3);
+	} else
 	if (id[2] >= 16 && id[2] <= 31) {
 		n = 1ul << id[2];
 	} else


### PR DESCRIPTION
From the spansion datasheets, the id[2] identifies the capacity in the
following way:

S25FL127S: 18h // 128M
S25FL128S: 18h // 128M
S25FL256S: 19h // 256M
S25FL512S: 20h // 512M
