### PR TITLE
Bugfix blockSize (Spansion chip, model with 256K sector size)

### DIFF
--- a/examples/CopyFromSerial/CopyFromSerial.ino
+++ b/examples/CopyFromSerial/CopyFromSerial.ino
@@ -96,7 +96,7 @@ void setup(){
   SerialFlash.begin(CSPIN);
 
   //We start by formatting the flash...
-  uint8_t id[3];
+  uint8_t id[5];
   SerialFlash.readID(id);
   SerialFlash.eraseAll();
   

--- a/examples/EraseEverything/EraseEverything.ino
+++ b/examples/EraseEverything/EraseEverything.ino
@@ -23,7 +23,7 @@ void setup() {
   delay(100);
 
   SerialFlash.begin(FlashChipSelect);
-  unsigned char id[3];
+  unsigned char id[5];
   SerialFlash.readID(id);
   unsigned long size = SerialFlash.capacity(id);
 


### PR DESCRIPTION
Hi Paul,

The Spansion cards can have 64Kb or 256Kb depending on the model's
number. The device id[4] must be checked to determine the sector
architecture.
You can check in the datasheet:
http://www.spansion.com/Support/Datasheets/S25FL128S_256S_00.pdf
Page 136, that the model's number define if the chip has a 256Kb or 64Kb sector size.
In page 120, we can see that we can use the ID[4] to determine this.

I notice this issue because I have a 256Kb sector size Spansion S25FL256S chip, and when I was trying to erase the second sector using the eraseBlock(blockSize()), it was also erasing the first sector.

Maybe it is not a good solution to expand the size of the id and maybe we should use another variable to this, or is this patch good enough for now? What do you think?

Thank you
