### PR TITLE
capacity: return 0 for wrong id

### DIFF
--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -446,6 +446,10 @@ uint32_t SerialFlashChip::capacity(const uint8_t *id)
 	} else
 	if (id[2] >= 32 && id[2] <= 37) {
 		n = 1ul << (id[2] - 6);
+	} else
+	if ((id[0]==0 && id[1]==0 && id[2]==0) || 
+		(id[0]==255 && id[1]==255 && id[2]==255)) {
+		n = 0;
 	}
 	//Serial.printf("capacity %lu\n", n);
 	return n;


### PR DESCRIPTION
it checks for all bytes=0 or 0xff (the pin might be hold low or high by other connections)
