### PR TITLE
SerialFlash: enlarge chip ID buffer

### DIFF
--- a/SerialFlashDirectory.cpp
+++ b/SerialFlashDirectory.cpp
@@ -310,7 +310,7 @@ bool SerialFlashChip::create(const char *filename, uint32_t length, uint32_t ali
 	// last check, if enough space exists...
 	len = strlen(filename);
 	// TODO: check for enough string space for filename
-	uint8_t id[3];
+	uint8_t id[5];
 	SerialFlash.readID(id);
 	if (address + length > SerialFlash.capacity(id)) return false;
 


### PR DESCRIPTION
SerialFlashChip::readID() writes up to 5 bytes into
the buffer provided, but the caller only allocates
3 bytes. Increase buffer size to 5 bytes.
