### PR TITLE
Dynamically switch SPI port in use

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -36,6 +36,7 @@ class SerialFlashFile;
 class SerialFlashChip
 {
 public:
+	static bool begin(SPIClass& device, uint8_t pin = 6);
 	static bool begin(uint8_t pin = 6);
 	static uint32_t capacity(const uint8_t *id);
 	static uint32_t blockSize();

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -32,22 +32,14 @@
 #define CSRELEASE() DIRECT_WRITE_HIGH(cspin_basereg, cspin_bitmask)
 #define SPICONFIG   SPISettings(50000000, MSBFIRST, SPI_MODE0)
 
-#if defined(__arc__)
-// Use SPI1 on Arduino 101 (accesses chip already on the board)
-#define SPIPORT SPI1
-#elif 0
-// Add cases here, if you wish to use other SPI ports...
-#else
-// Otherwise, use the normal SPI port.
-#define SPIPORT SPI
-#endif
-
 uint16_t SerialFlashChip::dirindex = 0;
 uint8_t SerialFlashChip::flags = 0;
 uint8_t SerialFlashChip::busy = 0;
 
 static volatile IO_REG_TYPE *cspin_basereg;
 static IO_REG_TYPE cspin_bitmask;
+
+static SPIClass& SPIPORT = SPI;
 
 #define FLAG_32BIT_ADDR		0x01	// larger than 16 MByte address
 #define FLAG_STATUS_CMD70	0x02	// requires special busy flag check
@@ -340,6 +332,12 @@ bool SerialFlashChip::ready()
 //#define FLAG_STATUS_CMD70	0x02	// requires special busy flag check
 //#define FLAG_DIFF_SUSPEND	0x04	// uses 2 different suspend commands
 //#define FLAG_256K_BLOCKS	0x10	// has 256K erase blocks
+
+bool SerialFlashChip::begin(SPIClass& device, uint8_t pin)
+{
+	SPIPORT = device;
+	return begin(pin);
+}
 
 bool SerialFlashChip::begin(uint8_t pin)
 {


### PR DESCRIPTION
This allows "derived" libraries (like the one in Arduino101 core) to use both the onboard or an external flash, while avoiding forks

Still not sure about SPIClass, is it universal? I couldn't find a core declaring it differently but I'm quite sure it exists. Using `typeof` would be ok but it's a gcc extension; arc32 and esp8266 cores are currently passing `-std=c++11` instead than `-std=gnu++11` so gnu extensions are unavailable.

In case we want to use `typeof`, the extra patch is 

``` patch
diff --git a/SerialFlash.h b/SerialFlash.h
index 3c0a5ae..6f56f47 100644
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -31,12 +31,14 @@
 #include <Arduino.h>
 #include <SPI.h>

+#define SPICLASS typeof(SPI)
+
 class SerialFlashFile;

 class SerialFlashChip
 {
 public:
-   static bool begin(SPIClass& device, uint8_t pin = 6);
+   static bool begin(SPICLASS& device, uint8_t pin = 6);
    static bool begin(uint8_t pin = 6);
    static uint32_t capacity(const uint8_t *id);
    static uint32_t blockSize();
diff --git a/SerialFlashChip.cpp b/SerialFlashChip.cpp
index 7af00d2..e7324f7 100644
--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -39,7 +39,7 @@ uint8_t SerialFlashChip::busy = 0;
 static volatile IO_REG_TYPE *cspin_basereg;
 static IO_REG_TYPE cspin_bitmask;

-static SPIClass& SPIPORT = SPI;
+static SPICLASS& SPIPORT = SPI;

 #define FLAG_32BIT_ADDR        0x01    // larger than 16 MByte address
 #define FLAG_STATUS_CMD70  0x02    // requires special busy flag check
```
