### PR TITLE
avoid init of spi in begin() when spi is handed as input

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -62,10 +62,9 @@ public:
 	static void opendir() { dirindex = 0; }
 	static bool readdir(char *filename, uint32_t strsize, uint32_t &filesize);
 
-    static uint8_t flags;	// chip features moved to public to be able to poll it
-private:
+   private:
 	static uint16_t dirindex; // current position for readdir()
-
+    static uint8_t flags;	// chip features
 	static uint8_t busy;	// 0 = ready
 				// 1 = suspendable program operation
 				// 2 = suspendable erase operation

--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -50,7 +50,7 @@ public:
 	static void write(uint32_t addr, const void *buf, uint32_t len);
 	static void eraseAll();
 	static void eraseBlock(uint32_t addr);
-
+    static void setflags(); //added to be able to update flags without calling begin
 	static SerialFlashFile open(const char *filename);
 	static bool create(const char *filename, uint32_t length, uint32_t align = 0);
 	static bool createErasable(const char *filename, uint32_t length) {
@@ -61,9 +61,11 @@ public:
 	static bool remove(SerialFlashFile &file);
 	static void opendir() { dirindex = 0; }
 	static bool readdir(char *filename, uint32_t strsize, uint32_t &filesize);
+
+    static uint8_t flags;	// chip features moved to public to be able to poll it
 private:
 	static uint16_t dirindex; // current position for readdir()
-	static uint8_t flags;	// chip features
+
 	static uint8_t busy;	// 0 = ready
 				// 1 = suspendable program operation
 				// 2 = suspendable erase operation

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -220,7 +220,7 @@ void SerialFlashChip::eraseAll()
 	if (busy) wait();
 	uint8_t id[5];
 	readID(id);
- //   Serial.printf("ID: %02X %02X %02X\n", id[0], id[1], id[2]);
+	//Serial.printf("ID: %02X %02X %02X\n", id[0], id[1], id[2]);
 	if (id[0] == 0x20 && id[2] >= 0x20 && id[2] <= 0x22) {
 		// Micron's multi-die chips require special die erase commands
 		//  N25Q512A	20 BA 20  2 dies  32 Mbyte/die   65 nm transitors
@@ -229,7 +229,7 @@ void SerialFlashChip::eraseAll()
 		uint8_t die_count = 2;
 		if (id[2] == 0x21) die_count = 4;
 		uint8_t die_index = flags >> 6;
-        // Serial.printf("Micron die erase %d\n", die_index);
+		 //Serial.printf("Micron die erase %d\n", die_index);
 		flags &= 0x3F;
 		if (die_index >= die_count) return; // all dies erased :-)
 		uint8_t die_size = 2;  // in 16 Mbyte units
@@ -337,7 +337,6 @@ bool SerialFlashChip::begin(SPIClass& device, uint8_t pin)
 {
 	SPIPORT = device;
     //we don't want to issue SPI.begin
-
     //as this potentially undoes specific changes made in the SPI that is handed over to us
     cspin_basereg = PIN_TO_BASEREG(pin);
     cspin_bitmask = PIN_TO_BITMASK(pin);
@@ -346,21 +345,21 @@ bool SerialFlashChip::begin(SPIClass& device, uint8_t pin)
     setflags();
     return true;
 }
-
 bool SerialFlashChip::begin(uint8_t pin)
 {
-	cspin_basereg = PIN_TO_BASEREG(pin);
-	cspin_bitmask = PIN_TO_BITMASK(pin);
-	SPIPORT.begin();
-	pinMode(pin, OUTPUT);
-	CSRELEASE();
+    cspin_basereg = PIN_TO_BASEREG(pin);
+    cspin_bitmask = PIN_TO_BITMASK(pin);
+    SPIPORT.begin();
+    pinMode(pin, OUTPUT);
+    CSRELEASE();
     setflags();
     return true;
 }
-void SerialFlashChip::setflags(){
-    uint8_t id[5];
-    uint8_t f;
-    uint32_t size;
+void SerialFlashChip::setflags()
+{
+	uint8_t id[5];
+	uint8_t f;
+	uint32_t size;
 	readID(id);
 	f = 0;
 	size = capacity(id);
@@ -396,11 +395,10 @@ void SerialFlashChip::setflags(){
 	}
 	if (id[0] == ID0_MICRON) {
 		// Micron requires busy checks with a different command
-        f |= FLAG_STATUS_CMD70; // TODO: all or just multi-die chips?
+		f |= FLAG_STATUS_CMD70; // TODO: all or just multi-die chips?
 	}
 	flags = f;
 	readID(id);
-
 }
 
 // chips tested: https://github.com/PaulStoffregen/SerialFlash/pull/12#issuecomment-169596992

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -62,6 +62,8 @@ void SerialFlashChip::wait(void)
 			status = SPIPORT.transfer(0);
 			CSRELEASE();
 			SPIPORT.endTransaction();
+            sprintf(tbs,"b=%02x.", status & 0xFF);
+            Serial.write(tbs);
 			//Serial.printf("b=%02x.", status & 0xFF);
 			if ((status & 0x80)) break;
 		} else {
@@ -220,7 +222,7 @@ void SerialFlashChip::eraseAll()
 	if (busy) wait();
 	uint8_t id[5];
 	readID(id);
-	//Serial.printf("ID: %02X %02X %02X\n", id[0], id[1], id[2]);
+ //   Serial.printf("ID: %02X %02X %02X\n", id[0], id[1], id[2]);
 	if (id[0] == 0x20 && id[2] >= 0x20 && id[2] <= 0x22) {
 		// Micron's multi-die chips require special die erase commands
 		//  N25Q512A	20 BA 20  2 dies  32 Mbyte/die   65 nm transitors
@@ -229,7 +231,7 @@ void SerialFlashChip::eraseAll()
 		uint8_t die_count = 2;
 		if (id[2] == 0x21) die_count = 4;
 		uint8_t die_index = flags >> 6;
-		 //Serial.printf("Micron die erase %d\n", die_index);
+        // Serial.printf("Micron die erase %d\n", die_index);
 		flags &= 0x3F;
 		if (die_index >= die_count) return; // all dies erased :-)
 		uint8_t die_size = 2;  // in 16 Mbyte units
@@ -336,20 +338,31 @@ bool SerialFlashChip::ready()
 bool SerialFlashChip::begin(SPIClass& device, uint8_t pin)
 {
 	SPIPORT = device;
-	return begin(pin);
+    //we don't want to issue SPI.begin
+
+    //as this potentially undoes specific changes made in the SPI that is handed over to us
+    cspin_basereg = PIN_TO_BASEREG(pin);
+    cspin_bitmask = PIN_TO_BITMASK(pin);
+    pinMode(pin, OUTPUT);
+    CSRELEASE();
+    setflags();
+    return true;
 }
 
 bool SerialFlashChip::begin(uint8_t pin)
 {
-	uint8_t id[5];
-	uint8_t f;
-	uint32_t size;
-
 	cspin_basereg = PIN_TO_BASEREG(pin);
 	cspin_bitmask = PIN_TO_BITMASK(pin);
 	SPIPORT.begin();
 	pinMode(pin, OUTPUT);
 	CSRELEASE();
+    setflags();
+    return true;
+}
+void SerialFlashChip::setflags(){
+    uint8_t id[5];
+    uint8_t f;
+    uint32_t size;
 	readID(id);
 	f = 0;
 	size = capacity(id);
@@ -385,11 +398,11 @@ bool SerialFlashChip::begin(uint8_t pin)
 	}
 	if (id[0] == ID0_MICRON) {
 		// Micron requires busy checks with a different command
-		f |= FLAG_STATUS_CMD70; // TODO: all or just multi-die chips?
+        f |= FLAG_STATUS_CMD70; // TODO: all or just multi-die chips?
 	}
 	flags = f;
 	readID(id);
-	return true;
+
 }
 
 // chips tested: https://github.com/PaulStoffregen/SerialFlash/pull/12#issuecomment-169596992

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -62,8 +62,6 @@ void SerialFlashChip::wait(void)
 			status = SPIPORT.transfer(0);
 			CSRELEASE();
 			SPIPORT.endTransaction();
-            sprintf(tbs,"b=%02x.", status & 0xFF);
-            Serial.write(tbs);
 			//Serial.printf("b=%02x.", status & 0xFF);
 			if ((status & 0x80)) break;
 		} else {


### PR DESCRIPTION
Small change to avoid re-invoking SPI.begin() is SPI object that is handed to us in the constructor. This is useful if like me, you need to hack the SPI object to make it work e.g. on pins 11-13 on an Arduino M0 Pro. 
Not sure if it would break other uses of the code (should only be those that require passing an SPI object and can be fixed by invoking SPI.begin() on the user side before passing it to SerialFlash.begin().

Not sure if I am following proper github etiquette, but seemed a useful change to the library and it helps me staying up to date with later updates of this library.