### PR TITLE
Improvements to readSerialNumber Method

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -44,6 +44,7 @@ public:
 	static void wakeup();
 	static void readID(uint8_t *buf);
 	static void readSerialNumber(uint8_t *buf);
+	static void readSFDP(uint8_t* buf, uint8_t addr, uint16_t len);
 	static void read(uint32_t addr, void *buf, uint32_t len);
 	static bool ready();
 	static void wait();
@@ -68,6 +69,7 @@ private:
 				// 1 = suspendable program operation
 				// 2 = suspendable erase operation
 				// 3 = busy for realz!!
+	static uint8_t chipID;
 };
 
 extern SerialFlashChip SerialFlash;


### PR DESCRIPTION
Added variable chipID to save when readID is first called in begin().  Can be retrieved later without calling readID() again. Command bytes can be determined by chipID in readSerialNumber.  Spansion chips need command byte 0x5A, SST 0x88.  

Added readSerialNumber() and readSFDP().  Method readSFDP() is used to support readSerialNumber(). Tested with Spansion S25FL127S and Spansion S25FL116K.

Chips that support but have not been tested:
	- SST SST26VF032
	- Winbond W25Q16JV

Chips that do not support SerialNumber (UniqueID):
 - Macronix MX25L12805D
 - Macronix MX66L51235F
 - Numonyx M25P128
 - Micron M25P80
 - Micron N25Q128A
 - SST SST25WF010