### PR TITLE
Make SPICONFIG configurable

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -36,6 +36,8 @@ class SerialFlashFile;
 class SerialFlashChip
 {
 public:
+        static bool begin(SPIClass& device, SPISettings config, uint8_t pin = 6);
+        static bool begin(SPISettings config, uint8_t pin = 6);
 	static bool begin(SPIClass& device, uint8_t pin = 6);
 	static bool begin(uint8_t pin = 6);
 	static uint32_t capacity(const uint8_t *id);

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -30,7 +30,6 @@
 
 #define CSASSERT()  DIRECT_WRITE_LOW(cspin_basereg, cspin_bitmask)
 #define CSRELEASE() DIRECT_WRITE_HIGH(cspin_basereg, cspin_bitmask)
-#define SPICONFIG   SPISettings(50000000, MSBFIRST, SPI_MODE0)
 
 uint16_t SerialFlashChip::dirindex = 0;
 uint8_t SerialFlashChip::flags = 0;
@@ -40,6 +39,7 @@ static volatile IO_REG_TYPE *cspin_basereg;
 static IO_REG_TYPE cspin_bitmask;
 
 static SPIClass& SPIPORT = SPI;
+static SPISettings SPICONFIG = SPISettings(50000000, MSBFIRST, SPI_MODE0);
 
 #define FLAG_32BIT_ADDR		0x01	// larger than 16 MByte address
 #define FLAG_STATUS_CMD70	0x02	// requires special busy flag check
@@ -333,6 +333,19 @@ bool SerialFlashChip::ready()
 //#define FLAG_DIFF_SUSPEND	0x04	// uses 2 different suspend commands
 //#define FLAG_256K_BLOCKS	0x10	// has 256K erase blocks
 
+bool SerialFlashChip::begin(SPIClass& device, SPISettings config, uint8_t pin)
+{
+        SPIPORT = device;
+        SPICONFIG = config;
+
+        return begin(pin);
+}
+bool SerialFlashChip::begin(SPISettings config, uint8_t pin)
+{
+        SPICONFIG = config;
+
+        return begin(pin);
+}
 bool SerialFlashChip::begin(SPIClass& device, uint8_t pin)
 {
 	SPIPORT = device;


### PR DESCRIPTION
In order to support ESP32, we need to be able to change the max speed from the SPICONFIG. This pull request is related to #57.