### PR TITLE
Enabling 4kb sector erase and smaller erasable filesizes on winbond chips

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -40,6 +40,7 @@ public:
 	static bool begin(uint8_t pin = 6);
 	static uint32_t capacity(const uint8_t *id);
 	static uint32_t blockSize();
+	static uint32_t eraseSectorSize();
 	static void sleep();
 	static void wakeup();
 	static void readID(uint8_t *buf);
@@ -50,12 +51,11 @@ public:
 	static void write(uint32_t addr, const void *buf, uint32_t len);
 	static void eraseAll();
 	static void eraseBlock(uint32_t addr);
+	static void eraseSector(uint32_t addr);
 
 	static SerialFlashFile open(const char *filename);
 	static bool create(const char *filename, uint32_t length, uint32_t align = 0);
-	static bool createErasable(const char *filename, uint32_t length) {
-		return create(filename, length, blockSize());
-	}
+	static bool createErasable(const char *filename, uint32_t length);
 	static bool exists(const char *filename);
 	static bool remove(const char *filename);
 	static bool remove(SerialFlashFile &file);

--- a/SerialFlashChip.cpp
+++ b/SerialFlashChip.cpp
@@ -504,7 +504,6 @@ uint32_t SerialFlashChip::blockSize()
 	if (flags & FLAG_256K_BLOCKS) return 262144;
 	// everything else seems to have 64K sectors
 	return 65536;
-	asdf;
 }
 
 uint32_t SerialFlashChip::eraseSectorSize()

--- a/SerialFlashDirectory.cpp
+++ b/SerialFlashDirectory.cpp
@@ -330,6 +330,14 @@ bool SerialFlashChip::create(const char *filename, uint32_t length, uint32_t ali
 	return true;
 }
 
+bool SerialFlashChip::createErasable(const char *filename, uint32_t length) {
+	uint32_t filesize = SerialFlash.eraseSectorSize();
+	while (length > filesize) {
+		filesize = filesize * 2;
+	}
+	return create(filename, length, filesize);
+}
+
 bool SerialFlashChip::readdir(char *filename, uint32_t strsize, uint32_t &filesize)
 {
 	uint32_t maxfiles, index, straddr;
@@ -383,7 +391,7 @@ void SerialFlashFile::erase()
 {
 	uint32_t i, blocksize;
 
-	blocksize = SerialFlash.blockSize();
+	blocksize = SerialFlash.eraseSectorSize();
 	if (address & (blocksize - 1)) return; // must begin on a block boundary
 	if (length & (blocksize - 1)) return;  // must be exact number of blocks
 	for (i=0; i < length; i += blocksize) {

--- a/SerialFlashDirectory.cpp
+++ b/SerialFlashDirectory.cpp
@@ -389,13 +389,19 @@ bool SerialFlashChip::readdir(char *filename, uint32_t strsize, uint32_t &filesi
 
 void SerialFlashFile::erase()
 {
-	uint32_t i, blocksize;
+	uint32_t i, blockSize, sectorSize;
 
-	blocksize = SerialFlash.eraseSectorSize();
-	if (address & (blocksize - 1)) return; // must begin on a block boundary
-	if (length & (blocksize - 1)) return;  // must be exact number of blocks
-	for (i=0; i < length; i += blocksize) {
-		SerialFlash.eraseBlock(address + i);
+	blockSize = SerialFlash.blockSize();
+	sectorSize = SerialFlash.eraseSectorSize();
+
+	if (address & (sectorSize - 1)) return; // must begin on a block boundary
+	if (length & (sectorSize - 1)) return;  // must be exact number of blocks
+	for (i=0; i < length; i += sectorSize) {
+		if (sectorSize < blockSize) {
+			SerialFlash.eraseSector(address + i);
+		} else {
+			SerialFlash.eraseBlock(address + i);
+		}
 	}
 }
 


### PR DESCRIPTION
This feature takes advantage of winbond's 4kb sector-erase feature to enable smaller erasable filesizes.

I noticed that I couldn't save more than 16 erasable files to my winbond w25q80, and did some investigating into this library's size allocation. I discovered that it assumes all chips use 256kb erase blocks, so I added a feature detection flag for winbond chips and auto-sizing function for erasable files smaller than 256kb. (Right now this auto-size feature uses powers of two but could potentially work in 4kb blocks instead.) 

This is tested in hardware on the w25q80 and seems to work fine! So far as I can tell from reading datasheets all winbond serial flash uses 4kb erase sectors, but I am not super-familiar with their product lines so would appreciate a double-check.

The erase function looks quite different but is substantially the same, and should accommodate alternate erase sector sizes if other manufacturers use them.