### PR TITLE
Software reset for chips w/o reset pin (W25Q64FV)

### DIFF
--- a/SerialFlash.h
+++ b/SerialFlash.h
@@ -50,7 +50,8 @@ public:
 	static void write(uint32_t addr, const void *buf, uint32_t len);
 	static void eraseAll();
 	static void eraseBlock(uint32_t addr);
-
+  static void reset();
+  
 	static SerialFlashFile open(const char *filename);
 	static bool create(const char *filename, uint32_t length, uint32_t align = 0);
 	static bool createErasable(const char *filename, uint32_t length) {

--- a/keywords.txt
+++ b/keywords.txt
@@ -7,3 +7,4 @@ ready	KEYWORD2
 create	KEYWORD2
 createWritable	KEYWORD2
 getAddress	KEYWORD2
+reset	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SerialFlash
-version=0.5
+version=0.6
 author=Paul Stoffregen
 maintainer=Paul Stoffregen
 sentence=Access SPI Serial Flash memory with filesystem-like functions


### PR DESCRIPTION
Based on the following from the datasheet of W25Q64FV
7.2.43 Enable Reset (66h) and Reset (99h)
Because of the small package and the limitation on the number of pins, the W25Q64FV provide a
software Reset instruction instead of a dedicated RESET pin. Once the Reset instruction is accepted, any
on-going internal operations will be terminated and the device will return to its default power-on state and
lose all the current volatile settings, such as Volatile Status Register bits, Write Enable Latch (WEL)
status, Program/Erase Suspend status, Read parameter setting (P7-P0), Continuous Read Mode bit
setting (M7-M0) and Wrap Bit setting (W6-W4).
“Enable Reset (66h)” and “Reset (99h)” instructions can be issued in either SPI mode or QPI mode. To
avoid accidental reset, both instructions must be issued in sequence. Any other commands other than
“Reset (99h)” after the “Enable Reset (66h)” command will disable the “Reset Enable” state. A new
sequence of “Enable Reset (66h)” and “Reset (99h)” is needed to reset the device. Once the Reset
command is accepted by the device, the device will take approximately tRST=30us to reset. During this
period, no command will be accepted.
Data corruption may happen if there is an on-going or suspended internal Erase or Program operation
when Reset command sequence is accepted by the device. It is recommended to check the BUSY bit and
the SUS bit in Status Register before issuing the Reset command sequence.

added SerialFlash.reset() method (tested on W25Q64FV)